### PR TITLE
Fixes #146 Add to docker matrix other interpreters

### DIFF
--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -5,6 +5,7 @@ FROM $IMAGE_FROM
 ARG BDATE
 ARG SCOMMIT
 ARG PIP_PACKAGES="pip setuptools wheel"
+ARG PYTHON_INSTALLERS="2.7.10 3.4.9 3.5.7 3.6.7 3.7.1"
 
 # Image labels (see ./hooks/build for ARGS)
 LABEL "org.label-schema.name"="skycoindev-python" \
@@ -68,16 +69,17 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
     && git submodule update --init --recursive \
     && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
     && bash -c "eval "$(pyenv virtualenv-init -)"" \
-    && pyenv install 2.7.10 \
-    && pyenv install 3.4.9 \
-    && pyenv install 3.5.7 \
-    && pyenv install 3.6.7 \
-    && pyenv install 3.7.1 \
-    && pyenv virtualenv 2.7.10 pysky27 \
-    && pyenv virtualenv 3.4.9 pysky34 \
-    && pyenv virtualenv 3.5.7 pysky35 \
-    && pyenv virtualenv 3.6.7 pysky36 \
-    && pyenv virtualenv 3.7.1 pysky37 \
+	&& for installer in $PYTHON_INSTALLERS; do pyenv install $installer; pyenv virtualenv $installer pysky($installer); done \
+    #&& pyenv install 2.7.10 \
+    #&& pyenv install 3.4.9 \
+    #&& pyenv install 3.5.7 \
+    #&& pyenv install 3.6.7 \
+    #&& pyenv install 3.7.1 \
+    #&& pyenv virtualenv 2.7.10 pysky27 \
+    #&& pyenv virtualenv 3.4.9 pysky34 \
+    #&& pyenv virtualenv 3.5.7 pysky35 \
+    #&& pyenv virtualenv 3.6.7 pysky36 \
+    #&& pyenv virtualenv 3.7.1 pysky37 \
     && . $PYENV_ROOT/versions/pysky27/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
     && . $PYENV_ROOT/versions/pysky34/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
     && . $PYENV_ROOT/versions/pysky35/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -5,6 +5,7 @@ FROM $IMAGE_FROM
 ARG BDATE
 ARG SCOMMIT
 ARG PIP_PACKAGES="pip setuptools wheel"
+ARG PYTHON_INSTALLERS="2.7.10 3.4.9 3.5.7 3.6.7 3.7.1"
 
 # Image labels (see ./hooks/build for ARGS)
 LABEL "org.label-schema.name"="skycoindev-python" \
@@ -68,16 +69,17 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
     && git submodule update --init --recursive \
     && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
     && bash -c "eval "$(pyenv virtualenv-init -)"" \
-    && pyenv install 2.7.10 \
-    && pyenv install 3.4.9 \
-    && pyenv install 3.5.7 \
-    && pyenv install 3.6.7 \
-    && pyenv install 3.7.1 \
-    && pyenv virtualenv 2.7.10 pysky27 \
-    && pyenv virtualenv 3.4.9 pysky34 \
-    && pyenv virtualenv 3.5.7 pysky35 \
-    && pyenv virtualenv 3.6.7 pysky36 \
-    && pyenv virtualenv 3.7.1 pysky37 \
+	&& for installer in $(echo $PYTHON_INSTALLERS | tr " " "\n"); do pyenv install $installer; pyenv virtualenv $installer pysky$installer; done \
+    #&& pyenv install 2.7.10 \
+    #&& pyenv install 3.4.9 \
+    #&& pyenv install 3.5.7 \
+    #&& pyenv install 3.6.7 \
+    #&& pyenv install 3.7.1 \
+    #&& pyenv virtualenv 2.7.10 pysky27 \
+    #&& pyenv virtualenv 3.4.9 pysky34 \
+    #&& pyenv virtualenv 3.5.7 pysky35 \
+    #&& pyenv virtualenv 3.6.7 pysky36 \
+    #&& pyenv virtualenv 3.7.1 pysky37 \
     && . $PYENV_ROOT/versions/pysky27/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
     && . $PYENV_ROOT/versions/pysky34/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
     && . $PYENV_ROOT/versions/pysky35/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -5,7 +5,7 @@ FROM $IMAGE_FROM
 ARG BDATE
 ARG SCOMMIT
 ARG PIP_PACKAGES="pip setuptools wheel"
-ARG PYTHON_INSTALLERS="2.7.10 3.4.9 3.5.7 3.6.7 3.7.1"
+ARG PYTHON_INSTALLERS="2.7.10 3.4.9 3.5.7 3.6.7 3.7.1 jython-2.7.1 pypy2.7-7.1.0 pypy3.5-7.0.0 pypy3.6-7.1.1 activepython-2.7.14 activepython-3.5.4 activepython-3.6.0 stackless-2.7.10 stackless-2.7.10 stackless-3.4.7 stackless-3.5.4 ironpython-2.7.7"
 
 # Image labels (see ./hooks/build for ARGS)
 LABEL "org.label-schema.name"="skycoindev-python" \

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -4,7 +4,7 @@ FROM $IMAGE_FROM
 
 ARG BDATE
 ARG SCOMMIT
-ARG PIP_PACKAGES="pip setuptools wheel"
+ARG PIP_PACKAGES="setuptools wheel"
 
 # Image labels (see ./hooks/build for ARGS)
 LABEL "org.label-schema.name"="skycoindev-python" \
@@ -23,6 +23,11 @@ LABEL "org.label-schema.name"="skycoindev-python" \
 RUN set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+		python2.7-dev \
+		python3.5 \
+		python3.5-dev \
+		python-dev \
+		python3-dev \
 		ca-certificates \
 		libexpat1 \
 		libffi6 \
@@ -32,57 +37,199 @@ RUN set -ex \
 		libssl1.1 \
 		netbase \
 		wget \
-		make \
-		build-essential \
-		libssl1.0-dev \
-		zlib1g-dev \
-		libbz2-dev \
-        libreadline-dev \
-        libsqlite3-dev \
-        wget \
-        curl \
-        llvm \
-        libncurses5-dev \
-        libncursesw5-dev \
-        xz-utils \
-        tk-dev \
-        libffi-dev \
-        liblzma-dev \
-        git \
-        && git clone git://github.com/yyuu/pyenv.git ~/.pyenv \
-        && rm -rf ~/.pyenv/plugins/pyenv-virtualenv \
-        && git clone https://github.com/yyuu/pyenv-virtualenv.git ~/.pyenv/plugins/pyenv-virtualenv
+		python-pip \
+		python3-pip \
+    && pip install --upgrade pip \
+    && pip3 install --upgrade pip
 
-ENV HOME  /root
-ENV PROJECT_ROOT /source
-ENV PYENV_ROOT $HOME/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+# Install Python 3.7
+# runtime dependencies
+ENV PYTHON_VERSION 3.7.1
+RUN set -ex \
+	&& buildDeps=" \
+		libexpat1-dev \
+		tcl-dev \
+		tk-dev \
+    # as of Stretch, "gpg" is no longer included by default
+		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
+	" \
+	&& apt-get install -y $buildDeps --no-install-recommends \
+	\
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& for server in ha.pool.sks-keyservers.net \
+              hkp://p80.pool.sks-keyservers.net:80 \
+              keyserver.ubuntu.com \
+              hkp://keyserver.ubuntu.com:80 ;do\
+	      gpg --keyserver "$server" --recv-keys 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D;done \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+        --prefix=/usr \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make altinstall \
+	&& ldconfig \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
 
-RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
-    && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
-    && echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc \
-    && bash \
-    && git clone https://github.com/skycoin/pyskycoin.git $PROJECT_ROOT/pyskycoin \
-    && cd $PROJECT_ROOT/pyskycoin \
-    && git checkout v0.25.0 \
-    && git submodule update --init --recursive \
-    && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
-    && bash -c "eval "$(pyenv virtualenv-init -)"" \
-    && pyenv install 2.7.10 \
-    && pyenv install 3.4.9 \
-    && pyenv install 3.5.7 \
-    && pyenv install 3.6.7 \
-    && pyenv install 3.7.1 \
-    && pyenv virtualenv 2.7.10 pysky27 \
-    && pyenv virtualenv 3.4.9 pysky34 \
-    && pyenv virtualenv 3.5.7 pysky35 \
-    && pyenv virtualenv 3.6.7 pysky36 \
-    && pyenv virtualenv 3.7.1 pysky37 \
-    && . $PYENV_ROOT/versions/pysky27/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky34/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky35/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky36/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky37/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate
+# Install Python 3.6
+# runtime dependencies
+ENV PYTHON_VERSION 3.6.7
+RUN set -ex \
+	&& buildDeps=" \
+		libexpat1-dev \
+		tcl-dev \
+		tk-dev \
+    # as of Stretch, "gpg" is no longer included by default
+		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
+	" \
+	&& apt-get install -y $buildDeps --no-install-recommends \
+	\
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& for server in ha.pool.sks-keyservers.net \
+              hkp://p80.pool.sks-keyservers.net:80 \
+              keyserver.ubuntu.com \
+              hkp://keyserver.ubuntu.com:80 ;do\
+	      gpg --keyserver "$server" --recv-keys 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D;done \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+        --prefix=/usr \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make altinstall \
+	&& ldconfig \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
+
+# Install Python 3.4
+# runtime dependencies
+ENV PYTHON_VERSION 3.4.9
+RUN set -ex \
+	&& buildDeps=" \
+# as of Stretch, "gpg" is no longer included by default
+		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
+	" \
+	&& apt-get install -y libssl1.0-dev $buildDeps --no-install-recommends \
+	\
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& for server in ha.pool.sks-keyservers.net \
+              hkp://p80.pool.sks-keyservers.net:80 \
+              keyserver.ubuntu.com \
+              hkp://keyserver.ubuntu.com:80 ;do\
+	      gpg --keyserver "$server" --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D;done \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+        --prefix=/usr \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make altinstall \
+	&& ldconfig \
+	\
+    && apt-get install -y libssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 18.1
+RUN set -ex; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	\
+	python3.7 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	python3.6 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+    python3.5 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+    python3.4 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
+
+# Install packages in PIP_PACKAGES
+RUN pip install --upgrade $PIP_PACKAGES \
+    && pip3 install --upgrade $PIP_PACKAGES \
+    &&  python3.4 -m pip install --upgrade $PIP_PACKAGES \
+    &&  python3.6 -m pip install --upgrade $PIP_PACKAGES \
+    &&  python3.7 -m pip install --upgrade $PIP_PACKAGES
 
 WORKDIR $GOPATH/src/github.com/skycoin
 

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -5,6 +5,7 @@ FROM $IMAGE_FROM
 ARG BDATE
 ARG SCOMMIT
 ARG PIP_PACKAGES="pip setuptools wheel"
+ARG PYTHON_INSTALLERS="2.7.10 3.4.9 3.5.7 3.6.7 3.7.1"
 
 # Image labels (see ./hooks/build for ARGS)
 LABEL "org.label-schema.name"="skycoindev-python" \
@@ -68,21 +69,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
     && git submodule update --init --recursive \
     && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
     && bash -c "eval "$(pyenv virtualenv-init -)"" \
-    && pyenv install 2.7.10 \
-    && pyenv install 3.4.9 \
-    && pyenv install 3.5.7 \
-    && pyenv install 3.6.7 \
-    && pyenv install 3.7.1 \
-    && pyenv virtualenv 2.7.10 pysky27 \
-    && pyenv virtualenv 3.4.9 pysky34 \
-    && pyenv virtualenv 3.5.7 pysky35 \
-    && pyenv virtualenv 3.6.7 pysky36 \
-    && pyenv virtualenv 3.7.1 pysky37 \
-    && . $PYENV_ROOT/versions/pysky27/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky34/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky35/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky36/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
-    && . $PYENV_ROOT/versions/pysky37/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate
+	&& for installer in $(echo $PYTHON_INSTALLERS | tr " " "\n"); do pyenv install $installer; pyenv virtualenv $installer pysky$(echo $installer | cut -d. -f1,2 | tr -d .); . $PYENV_ROOT/versions/pysky$(echo $installer | cut -d. -f1,2 | tr -d .)/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate ;  done \
 
 WORKDIR $GOPATH/src/github.com/skycoin
 

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -4,7 +4,7 @@ FROM $IMAGE_FROM
 
 ARG BDATE
 ARG SCOMMIT
-ARG PIP_PACKAGES="setuptools wheel"
+ARG PIP_PACKAGES="pip setuptools wheel"
 
 # Image labels (see ./hooks/build for ARGS)
 LABEL "org.label-schema.name"="skycoindev-python" \
@@ -23,11 +23,6 @@ LABEL "org.label-schema.name"="skycoindev-python" \
 RUN set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-		python2.7-dev \
-		python3.5 \
-		python3.5-dev \
-		python-dev \
-		python3-dev \
 		ca-certificates \
 		libexpat1 \
 		libffi6 \
@@ -37,199 +32,57 @@ RUN set -ex \
 		libssl1.1 \
 		netbase \
 		wget \
-		python-pip \
-		python3-pip \
-    && pip install --upgrade pip \
-    && pip3 install --upgrade pip
+		make \
+		build-essential \
+		libssl1.0-dev \
+		zlib1g-dev \
+		libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        wget \
+        curl \
+        llvm \
+        libncurses5-dev \
+        libncursesw5-dev \
+        xz-utils \
+        tk-dev \
+        libffi-dev \
+        liblzma-dev \
+        git \
+        && git clone git://github.com/yyuu/pyenv.git ~/.pyenv \
+        && rm -rf ~/.pyenv/plugins/pyenv-virtualenv \
+        && git clone https://github.com/yyuu/pyenv-virtualenv.git ~/.pyenv/plugins/pyenv-virtualenv
 
-# Install Python 3.7
-# runtime dependencies
-ENV PYTHON_VERSION 3.7.1
-RUN set -ex \
-	&& buildDeps=" \
-		libexpat1-dev \
-		tcl-dev \
-		tk-dev \
-    # as of Stretch, "gpg" is no longer included by default
-		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
-	" \
-	&& apt-get install -y $buildDeps --no-install-recommends \
-	\
-	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& for server in ha.pool.sks-keyservers.net \
-              hkp://p80.pool.sks-keyservers.net:80 \
-              keyserver.ubuntu.com \
-              hkp://keyserver.ubuntu.com:80 ;do\
-	      gpg --keyserver "$server" --recv-keys 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D;done \
-	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
-	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
-	&& mkdir -p /usr/src/python \
-	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-	&& rm python.tar.xz \
-	\
-	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
-        --prefix=/usr \
-		--build="$gnuArch" \
-		--enable-loadable-sqlite-extensions \
-		--enable-shared \
-		--with-system-expat \
-		--with-system-ffi \
-		--without-ensurepip \
-	&& make -j "$(nproc)" \
-	&& make altinstall \
-	&& ldconfig \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
+ENV HOME  /root
+ENV PROJECT_ROOT /source
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
-# Install Python 3.6
-# runtime dependencies
-ENV PYTHON_VERSION 3.6.7
-RUN set -ex \
-	&& buildDeps=" \
-		libexpat1-dev \
-		tcl-dev \
-		tk-dev \
-    # as of Stretch, "gpg" is no longer included by default
-		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
-	" \
-	&& apt-get install -y $buildDeps --no-install-recommends \
-	\
-	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& for server in ha.pool.sks-keyservers.net \
-              hkp://p80.pool.sks-keyservers.net:80 \
-              keyserver.ubuntu.com \
-              hkp://keyserver.ubuntu.com:80 ;do\
-	      gpg --keyserver "$server" --recv-keys 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D;done \
-	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
-	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
-	&& mkdir -p /usr/src/python \
-	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-	&& rm python.tar.xz \
-	\
-	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
-        --prefix=/usr \
-		--build="$gnuArch" \
-		--enable-loadable-sqlite-extensions \
-		--enable-shared \
-		--with-system-expat \
-		--with-system-ffi \
-		--without-ensurepip \
-	&& make -j "$(nproc)" \
-	&& make altinstall \
-	&& ldconfig \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
-
-# Install Python 3.4
-# runtime dependencies
-ENV PYTHON_VERSION 3.4.9
-RUN set -ex \
-	&& buildDeps=" \
-# as of Stretch, "gpg" is no longer included by default
-		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
-	" \
-	&& apt-get install -y libssl1.0-dev $buildDeps --no-install-recommends \
-	\
-	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& for server in ha.pool.sks-keyservers.net \
-              hkp://p80.pool.sks-keyservers.net:80 \
-              keyserver.ubuntu.com \
-              hkp://keyserver.ubuntu.com:80 ;do\
-	      gpg --keyserver "$server" --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D;done \
-	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
-	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
-	&& mkdir -p /usr/src/python \
-	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-	&& rm python.tar.xz \
-	\
-	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
-        --prefix=/usr \
-		--build="$gnuArch" \
-		--enable-loadable-sqlite-extensions \
-		--enable-shared \
-		--with-system-expat \
-		--with-system-ffi \
-		--without-ensurepip \
-	&& make -j "$(nproc)" \
-	&& make altinstall \
-	&& ldconfig \
-	\
-    && apt-get install -y libssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python
-
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 18.1
-RUN set -ex; \
-	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	python3.7 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-	python3.6 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-    python3.5 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-    python3.4 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-	find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
-
-# Install packages in PIP_PACKAGES
-RUN pip install --upgrade $PIP_PACKAGES \
-    && pip3 install --upgrade $PIP_PACKAGES \
-    &&  python3.4 -m pip install --upgrade $PIP_PACKAGES \
-    &&  python3.6 -m pip install --upgrade $PIP_PACKAGES \
-    &&  python3.7 -m pip install --upgrade $PIP_PACKAGES
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc \
+    && bash \
+    && git clone https://github.com/skycoin/pyskycoin.git $PROJECT_ROOT/pyskycoin \
+    && cd $PROJECT_ROOT/pyskycoin \
+    && git checkout v0.25.0 \
+    && git submodule update --init --recursive \
+    && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
+    && bash -c "eval "$(pyenv virtualenv-init -)"" \
+    && pyenv install 2.7.10 \
+    && pyenv install 3.4.9 \
+    && pyenv install 3.5.7 \
+    && pyenv install 3.6.7 \
+    && pyenv install 3.7.1 \
+    && pyenv virtualenv 2.7.10 pysky27 \
+    && pyenv virtualenv 3.4.9 pysky34 \
+    && pyenv virtualenv 3.5.7 pysky35 \
+    && pyenv virtualenv 3.6.7 pysky36 \
+    && pyenv virtualenv 3.7.1 pysky37 \
+    && . $PYENV_ROOT/versions/pysky27/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
+    && . $PYENV_ROOT/versions/pysky34/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
+    && . $PYENV_ROOT/versions/pysky35/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
+    && . $PYENV_ROOT/versions/pysky36/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate \
+    && . $PYENV_ROOT/versions/pysky37/bin/activate && pip install --upgrade $PIP_PACKAGES && pip install pyskycoin && deactivate
 
 WORKDIR $GOPATH/src/github.com/skycoin
 


### PR DESCRIPTION
Fixes #146

Changes:
- Add supported versions of python for the next's implementation's:
  - jython 
  - pypy 
  - stackless
  - activePython
  - ironPython

Does this change need to mentioned in CHANGELOG.md?
Yes

